### PR TITLE
Add Separate Themed Version of issue.html with Dark/Light Mode Toggle

### DIFF
--- a/issue_alt.css
+++ b/issue_alt.css
@@ -1,0 +1,291 @@
+/* Base */ 
+body {
+  font-family: 'Karla', sans-serif;
+  margin: 0;
+  padding: 0;
+  background-color: #121417;
+  color: #e0e0e0;
+  transition: background-color 0.3s, color 0.3s;
+}
+
+/* Navbar */
+.navbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: #1a1d21;
+  padding: 1rem 2rem;
+  position: sticky;
+  top: 0;
+  z-index: 999;
+}
+
+.logo a {
+  font-family: 'Playfair Display', serif;
+  font-size: 1.8rem;
+  font-weight: bold;
+  color: #c52d2f;
+  text-decoration: none;
+}
+
+.nav-links {
+  display: flex;
+  gap: 20px;
+  list-style: none;
+  margin-right: 1rem;
+}
+
+.nav-links li a {
+  color: white;
+  text-decoration: none;
+  font-weight: bold;
+  padding: 5px 10px;
+  transition: all 0.2s ease;
+}
+
+.nav-links li a:hover {
+  color: rgb(148, 247, 237);
+  text-decoration: underline;
+  text-decoration: white 5px;
+}
+
+.nav-links li a.active {
+  border-bottom: 2px solid #5fa8a1;
+}
+
+#theme-toggle {
+  background: #f1ecec;
+  border: 1px solid black;
+  border-radius: 5px;
+  cursor: pointer;
+  padding: 4px;
+}
+
+#theme-toggle img {
+  width: 28px;
+  height: 28px;
+}
+
+.hamburger {
+  display: none;
+  font-size: 1.8rem;
+  background: none;
+  border: none;
+  color: white;
+  cursor: pointer;
+}
+
+@media (max-width: 768px) {
+  .hamburger {
+    display: block;
+  }
+
+  .nav-links {
+    flex-direction: column;
+    display: none;
+    background-color: #1a1d21;
+    position: absolute;
+    top: 60px;
+    right: 20px;
+    width: 60%;
+    padding: 2px;
+    border-radius: 8px;
+  }
+
+  .nav-links.active {
+    display: flex;
+  }
+}
+
+/* Hero */
+.hero {
+  text-align: center;
+  padding: 3rem 1rem;
+  background-color: #1a1d21;
+}
+
+.hero h1 {
+  font-family: 'Playfair Display', serif;
+  font-size: 2.5rem;
+  color: #c52d2f;
+}
+
+.hero p {
+  color: #5fa8a1;
+}
+
+/* Issue Cards */
+.issues-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2rem;
+  padding: 2rem;
+}
+
+.issue-card {
+  background-color: #1c1f23;
+  border: 1px solid #2a2e33;
+  border-radius: 12px;
+  padding: 1rem;
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.4);
+  transition: box-shadow 0.3s ease;
+}
+
+.issue-card:hover {
+  box-shadow: 0 0 10px rgba(100, 172, 164, 0.2);
+}
+
+.issue-card h2 {
+  color: #c52d2f;
+  font-family: 'Playfair Display', serif;
+  font-size: 1.4rem;
+}
+
+.issue-card p {
+  color: #cccccc;
+  margin-bottom: 1rem;
+}
+
+.btn {
+  display: inline-block;
+  background-color: #5fa8a1;
+  color: #ffffff;
+  padding: 0.5rem 1rem;
+  text-decoration: none;
+  border-radius: 6px;
+  font-weight: bold;
+  transition: background-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.btn:hover {
+  background-color: #407d79;
+  box-shadow: 0 0 6px rgba(95, 168, 161, 0.4);
+}
+
+/* Footer */
+.site-footer {
+  background-color: #1a1d21;
+  color: #cccccc;
+  padding: 3rem 1rem 2rem;
+}
+
+.footer-columns {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 2rem;
+  max-width: 1200px;
+  margin: auto;
+}
+
+.footer-column h3,
+.footer-column h4 {
+  font-family: 'Playfair Display', serif;
+  font-size: 1.2rem;
+  margin-bottom: 0.5rem;
+  color: #c52d2f;
+}
+
+.footer-column ul {
+  list-style: none;
+  padding: 0;
+}
+
+.footer-column ul li {
+  margin-bottom: 0.5rem;
+}
+
+.footer-column ul li a {
+  color: #cccccc;
+  text-decoration: none;
+  font-size: 0.95rem;
+}
+
+.footer-column ul li a:hover {
+  text-decoration: underline;
+}
+
+.footer-column ul li a i {
+  margin-right: 8px;
+  color: #c52d2f;
+  width: 20px;
+}
+
+.credit {
+  text-align: center;
+  font-size: 0.85rem;
+  margin-top: 2rem;
+  color: #888;
+}
+
+/* Light Mode */
+body.light-mode {
+  background-color: #ffffff;
+  color: #1a1a1a;
+}
+
+body.light-mode .navbar {
+  background-color: #fdf2f2;
+}
+
+body.light-mode .nav-links li a {
+  color: #1a1a1a;
+}
+
+body.light-mode .hero {
+  background-color: #5e0101;
+}
+
+body.light-mode .hero p {
+  color: #fffcfc;
+}
+body.light-mode .hero h1 {
+  color: #ffcaca;
+}
+
+body.light-mode .issue-card {
+  background-color: #ffffff;
+  border-color: #ddd;
+}
+body.light-mode .issue-card:hover {
+  box-shadow: 0 0 10px rgba(84, 30, 30, 0.929)
+}
+body.light-mode .issue-card p {
+  color: #000;
+}
+
+body.light-mode .btn {
+  background-color: #c52d2f;
+  color: white;
+}
+
+body.light-mode .btn:hover {
+  background-color: #ba4d5b;
+}
+
+body.light-mode .site-footer {
+  background-color: #5e0101;
+  color: #9d9c9c;
+}
+
+body.light-mode .footer-column ul li a {
+  color: #9d9c9c;
+}
+
+body.light-mode .footer-column p{
+  color: 	#9d9c9c;
+}
+body.light-mode .footer-column h3{
+  color: 	#f2e8dc;
+}
+
+body.light-mode .footer-column h4{
+  color: 	#f2e8dc;
+}
+body.light-mode .footer-column ul li a i {
+  color: #c52d2f;
+}
+
+body.light-mode .credit {
+  color: #ffffff;
+}

--- a/issue_alt.html
+++ b/issue_alt.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Issues – The Cawnpore Magazine</title>
+  <link rel="stylesheet" href="issue_alt.css">
+  <link href="https://fonts.googleapis.com/css2?family=Playfair+Display&family=Karla&display=swap" rel="stylesheet">
+</head>
+<body>                         
+  <!-- Header/Navbar -->
+  <nav class="navbar">
+    <div class="logo"><a href="index.html">The Cawnpore</a></div>
+
+    <ul class="nav-links" id="nav-links">
+      <li><a href="index.html">Home</a></li>
+      <li><a href="about.html">About</a></li>
+      <li><a href="submission.html">Submit</a></li>
+      <li><a href="issue.html" class="active">Issues</a></li>
+      <li><a href="masthead.html">Masthead</a></li>
+      <li><a href="faq.html">FAQ</a></li>
+      <li><a href="open-source.html">Open Source</a></li>
+    </ul>
+
+    <!-- Theme Toggle Button inside Navbar -->
+    <button id="theme-toggle" aria-label="Toggle Theme">
+      <img id="theme-icon" src="https://cdn-icons-png.flaticon.com/512/5662/5662790.png" alt="Sun icon" />
+    </button>
+
+    <!-- Mobile Hamburger Menu -->
+    <button class="hamburger" id="hamburger">&#9776;</button>
+  </nav>
+
+  <!-- Hero Section -->
+  <header class="hero">
+    <h1>Issues</h1>
+    <p>A collection of work that has grown with the community.</p>
+  </header>
+
+  <!-- Main Content -->
+  <main class="issues-grid">
+    <div class="issue-card">
+      <h2>Issue I</h2>
+      <p>A debut collection of voices, stories, and expression.</p>
+      <a href="#" class="btn">Read Issue</a>
+    </div>
+    <div class="issue-card">
+      <h2>Issue II</h2>
+      <p>Exploring memory, identity, and coming of age.</p>
+      <a href="#" class="btn">Read Issue</a>
+    </div>
+    <div class="issue-card">
+      <h2>Issue III</h2>
+      <p>Stories from in-between spaces — of time and place.</p>
+      <a href="#" class="btn">Read Issue</a>
+    </div>
+  </main>
+
+  <!-- Footer -->
+  <footer class="site-footer">
+    <div class="footer-columns">
+      <div class="footer-column">
+        <h3>The Cawnpore</h3>
+        <p>A space for young, desi, and diasporic voices.</p>
+      </div>
+      <div class="footer-column">
+        <h4>Navigation</h4>
+        <ul>
+          <li><a href="about.html">About</a></li>
+          <li><a href="submission.html">Submit</a></li>
+          <li><a href="issue.html">Issues</a></li>
+          <li><a href="masthead.html">Masthead</a></li>
+          <li><a href="faq.html">FAQ</a></li>
+          <li><a href="open-source.html">Open Source</a></li>
+        </ul>
+      </div>
+      <div class="footer-column">
+        <h4>Social</h4>
+        <ul>
+          <li>
+            <a href="https://www.instagram.com/thecawnporemagazine/" target="_blank">
+              <i class="fab fa-instagram"></i> Instagram
+            </a>
+          </li>
+          <li>
+            <a href="mailto:thecawnporemagazine@gmail.com">
+              <i class="fas fa-envelope"></i> Email Us
+            </a>
+          </li>
+        </ul>
+      </div>
+    </div>
+    <p class="credit">© 2025 The Cawnpore Magazine. Built with love by Kritika Singh.</p>
+  </footer>
+
+  <!-- JavaScript -->
+  <script>
+    document.addEventListener("DOMContentLoaded", () => {
+      const toggleBtn = document.getElementById('theme-toggle');
+      const icon = document.getElementById('theme-icon');
+      const navToggle = document.getElementById('hamburger');
+      const navLinks = document.getElementById('nav-links');
+
+      toggleBtn.addEventListener('click', () => {
+        document.body.classList.toggle('light-mode');
+        if (document.body.classList.contains('light-mode')) {
+          icon.src = 'https://cdn-icons-png.flaticon.com/512/6714/6714978.png';
+          icon.alt = 'Moon icon';
+        } else {
+          icon.src = 'https://cdn-icons-png.flaticon.com/512/5662/5662790.png';
+          icon.alt = 'Sun icon';
+        }
+      });
+
+      navToggle.addEventListener('click', () => {
+        navLinks.classList.toggle('active');
+      });
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
This PR introduces a new version of the issue.html` page  that supports dark and light mode switching (Issue Number:397).

🛠️ What I Added:
- A new HTML file (`issue_alt.html`) with dark/light theme toggle button added to the navbar.
- A new CSS file (`issue_alt.css`) that defines the styling for both dark and light modes.
- JavaScript included for toggling the theme with appropriate icons (sun/moon).

Screenshot:
Before :
<img width="1351" height="686" alt="before" src="https://github.com/user-attachments/assets/db0513ae-5ada-4836-9505-5defb9699e41" />

After: 

- [ ] Light mode

<img width="1351" height="696" alt="after light theme" src="https://github.com/user-attachments/assets/8cdb0e46-2e02-40b7-99b8-de44b747d542" />

- [ ] Dark Mode

<img width="1353" height="694" alt="after dark mode" src="https://github.com/user-attachments/assets/d0dc07da-fff5-4380-b760-86f542491df1" />


 ✅ Scope:
- This is a separate themed file and does not modify the existing `issue.html`.
- It serves as a preview/demo of how dark/light mode can be implemented on other pages.

🚀 Future Suggestion:
If this version is approved, I’d be happy to apply the same dark/light theme feature across all pages in the site for consistency 
or If any changes are needed in the current file or structure, I’d be happy to make the necessary updates.

Let me know if you'd like the theme applied to other pages as well!


